### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>at.favre.lib</groupId>


### PR DESCRIPTION
Bump commons-cli:commons-cli from 1.5.0 to 1.6.0
Bump commons-io:commons-io from 2.13.0 to 2.15.0
Bump org.slf4j:slf4j-jdk14 from 2.0.7 to 2.0.9
Bump org.projectlombok:lombok from 1.18.28 to 1.18.30
Bump org.apache.maven.plugins:maven-shade-plugin from 3.5.0 to 3.5.1
Bump org.apache.maven.plugins:maven-surefire-plugin from 3.1.2 to 3.2.2