### PR TITLE
Updated packages suggested by dependabot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.uio.ifi</groupId>
     <artifactId>crypt4gh</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <packaging>jar</packaging>
 
     <name>crypt4gh</name>
@@ -73,12 +73,12 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.15.1</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.16.1</version>
+            <version>1.17.1</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>2.0.12</version>
+            <version>2.0.16</version>
         </dependency>
 
         <dependency>
@@ -114,7 +114,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.13.0</version>
                     <configuration>
                         <annotationProcessorPaths>
                           <annotationProcessorPath>
@@ -128,12 +128,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.5.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -148,7 +148,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -179,7 +179,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.3</version>
                 <executions>
                     <execution>
                         <id>default-deploy</id>
@@ -194,7 +194,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -207,7 +207,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.6.3</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
commons-io.commons-io: 2.15.1 -> 2.17.0
commons-codec.commons-codec: 1.16.1 -> 1.17.1
org.slf4j.slf4j-jdk14: 2.0.12 -> 2.0.16
org.apache.maven.plugins.maven-compiler-plugin: 3.11.0 -> 3.13.0
org.apache.maven.plugins.maven-surefire-plugin: 3.2.2 -> 3.5.0
org.apache.maven.plugins.maven-jar-plugin: 3.3.0 -> 3.4.2
org.apache.maven.plugins.maven-shade-plugin: 3.5.1 -> 3.6.0
org.apache.maven.plugins.maven-deploy-plugin: 3.1.1 -> 3.1.3
org.apache.maven.plugins.maven-source-plugin: 3.3.0 -> 3.3.1
org.apache.maven.plugins.maven-javadoc-plugin: 3.6.3 -> 3.10.1
