### PR TITLE
Fix KEY_LENGTH for PBKDF2 by specifying it in bits rather than bytes

### DIFF
--- a/src/main/java/no/uio/ifi/crypt4gh/pojo/key/KDF.java
+++ b/src/main/java/no/uio/ifi/crypt4gh/pojo/key/KDF.java
@@ -38,7 +38,7 @@ public enum KDF {
             case BCRYPT:
                 return BKDF.createKdf().derive(salt, password, (int) (Math.log(rounds) / Math.log(2)), null, KEY_LENGTH);
             case PBKDF2_HMAC_SHA256:
-                KeySpec spec = new PBEKeySpec(password, salt, rounds, KEY_LENGTH);
+                KeySpec spec = new PBEKeySpec(password, salt, rounds, KEY_LENGTH*8);
                 SecretKeyFactory factory = SecretKeyFactory.getInstance(PBKDF_2_WITH_HMAC_SHA_256);
                 return factory.generateSecret(spec).getEncoded();
             case NONE:


### PR DESCRIPTION
The [KEY_LENGTH](https://github.com/ELIXIR-NO/FEGA-Norway/blob/563017c7e0cb21945a61a715f0d6fb9f8ecc25dd/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/pojo/key/KDF.java#L21) constant defined in the KDF.java file is set to 32, in order to stretch the user-supplied password into a 32 byte hash (256 bits) that can be used as the secret key for the ChaCha20 encryption algorithm.

However, with the current code, the PBKDF2_HMAC_SHA256 function only returns a 4 byte hash on [line 43](https://github.com/ELIXIR-NO/FEGA-Norway/blob/563017c7e0cb21945a61a715f0d6fb9f8ecc25dd/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/pojo/key/KDF.java#L43).
So, it seems that this function (but not SCRYPT and BCRYPT) requires the key length to be specified in bits rather than bytes, although this fact is not documented anywhere.

I don't think the "[case PBKDF2_HMAC_SHA256](https://github.com/ELIXIR-NO/FEGA-Norway/blob/563017c7e0cb21945a61a715f0d6fb9f8ecc25dd/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/pojo/key/KDF.java#L40C7-L43)" block has actually ever been tested before in context, because the ChaCha20 algorithm immediately returns an error if it is not provided with a 256 bits key.

By multiplying the KEY_LENGTH with 8, the PBKDF2_HMAC_SHA256 function returns a 256 bit key, as required, and the hash value is also identical to the one produced by the [Python-implementation](https://github.com/EGA-archive/crypt4gh/blob/7dc0d8b288397f006d7472c572bf4c82bfa2a3a4/crypt4gh/keys/kdf.py#L42) of Crypt4GH.
